### PR TITLE
Fix copy/paste error in switch statement controlling the LogonProvider

### DIFF
--- a/advapi32/LogonUser.ps1
+++ b/advapi32/LogonUser.ps1
@@ -98,7 +98,7 @@ function LogonUser
         'SERVICE' { 5 }
     }
 
-    $LogonProviderID = Switch ($LogonType) {
+    $LogonProviderID = Switch ($LogonProvider) {
         'DEFAULT' { 0 }
         'WINNT40' { 2 }
         'WINNT50' { 3 }


### PR DESCRIPTION
In response to https://github.com/jaredcatkinson/PSReflect-Functions/issues/15